### PR TITLE
Add enterprise wechat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### 欢迎指出bug，欢迎pull requests
 
-Windows版本微信客户端自动化，可实现简单的发送、接收微信消息、保存聊天图片
+Windows版本微信客户端自动化，可实现简单的发送、接收微信消息、保存聊天图片，现已支持企业微信
 
 **3.9.11.17版本微信安装包下载**：
 [点击下载](https://github.com/tom-snow/wechat-windows-versions/releases/download/v3.9.11.17/WeChatSetup-3.9.11.17.exe)
@@ -33,6 +33,8 @@ python窗口：
 >>> wxauto.VERSION
 '3.9.11.17'
 >>> wx = wxauto.WeChat()
+初始化成功，获取到已登录窗口：xxx
+>>> wx_work = wxauto.WeCom()  # 企业微信
 初始化成功，获取到已登录窗口：xxx
 ```
 

--- a/wxauto/__init__.py
+++ b/wxauto/__init__.py
@@ -1,9 +1,11 @@
 from .wxauto import WeChat
+from .wecom import WeCom
 from .utils import *
 
 __version__ = VERSION
 
 __all__ = [
-    'WeChat', 
+    'WeChat',
+    'WeCom',
     'VERSION',
 ]

--- a/wxauto/wecom.py
+++ b/wxauto/wecom.py
@@ -1,0 +1,6 @@
+from .wxauto import WeChat
+
+class WeCom(WeChat):
+    """企业微信自动化实例"""
+    def __init__(self, language: str = 'cn', debug: bool = False) -> None:
+        super().__init__(language=language, debug=debug, client='wecom')

--- a/wxauto/wxauto.py
+++ b/wxauto/wxauto.py
@@ -27,14 +27,19 @@ class WeChat(WeChatBase):
     def __init__(
             self, 
             language: Literal['cn', 'cn_t', 'en'] = 'cn', 
-            debug: bool = False
+            debug: bool = False,
+            client: Literal['wechat', 'wecom'] = 'wechat'
         ) -> None:
         """微信UI自动化实例
 
         Args:
             language (str, optional): 微信客户端语言版本, 可选: cn简体中文  cn_t繁体中文  en英文, 默认cn, 即简体中文
+            client (str, optional): 客户端类型, wechat为个人微信, wecom为企业微信
         """
-        self.UiaAPI: uia.WindowControl = uia.WindowControl(ClassName='WeChatMainWndForPC', searchDepth=1)
+        classname = 'WeChatMainWndForPC' if client == 'wechat' else 'WWA_MainWindow'
+        self.client = client
+        self._window_class = classname
+        self.UiaAPI: uia.WindowControl = uia.WindowControl(ClassName=self._window_class, searchDepth=1)
         set_debug(debug)
         self.language = language
         # self._checkversion()
@@ -74,16 +79,16 @@ class WeChat(WeChatBase):
         print(f'初始化成功，获取到已登录窗口：{self.nickname}')
     
     def _checkversion(self):
-        self.HWND = FindWindow(classname='WeChatMainWndForPC')
+        self.HWND = FindWindow(classname=self._window_class)
         wxpath = GetPathByHwnd(self.HWND)
         wxversion = GetVersionByPath(wxpath)
         if wxversion != self.VERSION:
             Warnings.lightred(self._lang('版本不一致', 'WARNING').format(wxversion, self.VERSION), stacklevel=2)
             return False
     
-    
+
     def _show(self):
-        self.HWND = FindWindow(classname='WeChatMainWndForPC')
+        self.HWND = FindWindow(classname=self._window_class)
         win32gui.ShowWindow(self.HWND, 1)
         win32gui.SetWindowPos(self.HWND, -1, 0, 0, 0, 0, 3)
         win32gui.SetWindowPos(self.HWND, -2, 0, 0, 0, 0, 3)


### PR DESCRIPTION
## Summary
- add Enterprise WeChat integration via `WeCom` class
- make window class configurable for personal and enterprise clients
- update package exports
- document the new class in README

## Testing
- `python -m compileall -q wxauto demo`
- `python demo.py` *(fails: ModuleNotFoundError: No module named 'comtypes')*

------
https://chatgpt.com/codex/tasks/task_e_68458f8dec08832bbd1c8ed0d9e3cc72